### PR TITLE
[fix] reviewImgUrl null 처리

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/templestay/api/service/ReviewService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/service/ReviewService.java
@@ -49,7 +49,9 @@ public class ReviewService {
                         review.getReviewName(),
                         review.getReviewDescription(),
                         DataUtils.formatReviewDate(review.getReviewDate()),
-                        "https://api.gototemplestay.com/api/image-proxy?imgUrl=" + review.getReviewImgUrl()
+                        review.getReviewImgUrl() != null
+                                ? "https://api.gototemplestay.com/api/image-proxy?imgUrl=" + review.getReviewImgUrl()
+                                : null
                 ))
                 .toList();
 


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #8 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- rivewRepository에서 reviewImgUrl이 null 이면 null값 그대로 반환할수있도록 수정
```
review.getReviewImgUrl() != null
                                ? "https://api.gototemplestay.com/api/image-proxy?imgUrl=" + review.getReviewImgUrl()
                                : null
```

## 📚 Reference



### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?